### PR TITLE
Add service unregistration methods to IServiceManager

### DIFF
--- a/service/src/main/java/org/akazukin/service/IServiceManager.java
+++ b/service/src/main/java/org/akazukin/service/IServiceManager.java
@@ -74,4 +74,37 @@ public interface IServiceManager<T extends IService> {
      */
     @Nullable
     T getServiceById(long serviceId);
+
+    /**
+     * Unregisters a service implementation from the service manager.
+     * This method removes the specified service implementation from the managed collection of services.
+     * If the provided implementation is not currently registered, no action is taken.
+     *
+     * @param <T2>        the type of the service implementation to unregister, extending the base type {@link T}
+     * @param serviceImpl the instance of the service implementation to be unregistered;
+     *                    must not be null
+     */
+    <T2 extends T> void unregisterService(@NotNull T2 serviceImpl);
+
+    /**
+     * Unregisters a service implementation from the service manager based on its implementation class.
+     * This method removes all instances of a registered service that match the provided implementation type.
+     * If no matching implementation is registered, no action is taken.
+     *
+     * @param <T2>        the type of the service implementation to unregister, extending the base type {@link T}
+     * @param serviceImpl the class object representing the implementation type of the service to be unregistered;
+     *                    must not be null
+     */
+    <T2 extends T> void unregisterServiceByImplementation(@NotNull Class<T2> serviceImpl);
+
+    /**
+     * Unregisters a service implementation using its interface type.
+     * This method removes all instances of services associated with the specified service interface class.
+     * If no matching implementation is registered, no action is taken.
+     *
+     * @param <T2>    the type of the service interface to unregister, extending the base type {@link T}
+     * @param service the class object representing the interface of the service to be unregistered;
+     *                must not be null
+     */
+    <T2 extends T> void unregisterServiceByInterface(@NotNull Class<T2> service);
 }

--- a/service/src/main/java/org/akazukin/service/ServiceManager.java
+++ b/service/src/main/java/org/akazukin/service/ServiceManager.java
@@ -8,6 +8,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -78,5 +79,20 @@ public class ServiceManager<T extends IService> implements IServiceManager<T> {
                 .findFirst()
                 .map(ServiceHolder::getImplementation)
                 .orElse(null);
+    }
+
+    @Override
+    public <T2 extends T> void unregisterService(@NotNull final T2 serviceImpl) {
+        this.services.removeIf(h -> Objects.equals(h.getImplementation(), serviceImpl));
+    }
+
+    @Override
+    public <T2 extends T> void unregisterServiceByImplementation(@NotNull final Class<T2> serviceImpl) {
+        this.services.removeIf(h -> Objects.equals(h.getImplementation().getClass(), serviceImpl));
+    }
+
+    @Override
+    public <T2 extends T> void unregisterServiceByInterface(@NotNull final Class<T2> service) {
+        this.services.removeIf(h -> Objects.equals(h.getInterfaceClass(), service));
     }
 }


### PR DESCRIPTION
Introduced three new methods to unregister services by instance, implementation class, or interface. Updated both `ServiceManager` and `IServiceManager` to support these operations, enabling more flexible service management.

<!-- Thank you for opening a PR! We really appreciate you taking the time to contribute 🙌 -->

#### What kind of changes does this PR include?

<!-- Delete any that don’t apply -->

- New or updated content

---

#### Description

- Closes # <!-- Add an issue number if this PR resolves one -->
- <!-- What does this PR change? Please provide a brief summary. -->

<!--
Did you make any visual changes? If so, a screenshot or video would be helpful.

Please keep your changes minimal and focused.
Pull requests with redundant code may be rejected.

If you create new classes or methods, adding documentation is appreciated.]


Pull request titles must be in English.
-->


---

