### PR TITLE
Fix service unregistration by using reference comparison

### DIFF
--- a/service/src/main/java/org/akazukin/service/ServiceManager.java
+++ b/service/src/main/java/org/akazukin/service/ServiceManager.java
@@ -83,7 +83,7 @@ public class ServiceManager<T extends IService> implements IServiceManager<T> {
 
     @Override
     public <T2 extends T> void unregisterService(@NotNull final T2 serviceImpl) {
-        this.services.removeIf(h -> Objects.equals(h.getImplementation(), serviceImpl));
+        this.services.removeIf(h -> h.getImplementation() == serviceImpl);
     }
 
     @Override


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to contribute 🙌 -->

#### What kind of changes does this PR include?

<!-- Delete any that don’t apply -->

- Minor content fixes (broken links, typos, exceptions, etc.)

---

#### Description

- Closes # <!-- Add an issue number if this PR resolves one -->
- Replaced `Objects.equals` with reference comparison to ensure proper unregistration of services. This prevents potential issues when services rely on object identity rather than equality.<!-- What does this PR change? Please provide a brief summary. -->

<!--
Did you make any visual changes? If so, a screenshot or video would be helpful.

Please keep your changes minimal and focused.
Pull requests with redundant code may be rejected.

If you create new classes or methods, adding documentation is appreciated.]


Pull request titles must be in English.
-->


---

